### PR TITLE
Add support for custom header auth

### DIFF
--- a/client.py
+++ b/client.py
@@ -59,7 +59,12 @@ SETTINGS = {
             "provider": {
               "type": "custom",
               "url": AZURE_URL,
-              "key": os.environ.get("AZURE_OPENAI_API_KEY"),
+              "headers": [
+                {
+                  "key": "api-key",
+                  "value": os.environ.get("AZURE_OPENAI_API_KEY")
+                }
+              ]
             },
             "model": LLM_MODEL,
             "instructions": PROMPT,


### PR DESCRIPTION
Custom auth header can be added using the following replacing the "key" method that adds `Authorization: Bearer sk-xxx`

```
headers: [
  {
    "key": "api-key",
    "value": "sk-xxx"
  }
]
```